### PR TITLE
fix: use relative static asset paths

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,8 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}GPT Team 管理系统{% endblock %}</title>
-    <link rel="icon" type="image/png" href="{{ url_for('static', path='/favicon.png') }}">
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}">
+    <link rel="icon" type="image/png" href="/static/favicon.png">
+    <link rel="stylesheet" href="/static/css/style.css">
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
     {% block extra_css %}{% endblock %}
@@ -347,7 +347,7 @@
     </div>
     <div id="toast" class="toast"></div>
 
-    <script src="{{ url_for('static', path='/js/main.js') }}"></script>
+    <script src="/static/js/main.js"></script>
     <script>
         lucide.createIcons();
     </script>

--- a/app/templates/user/redeem.html
+++ b/app/templates/user/redeem.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GPT Team 兑换</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/user.css') }}">
+    <link rel="stylesheet" href="/static/css/user.css">
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 </head>
@@ -103,7 +103,7 @@
     <!-- Toast提示 -->
     <div id="toast" class="toast"></div>
 
-    <script src="{{ url_for('static', path='/js/redeem.js') }}"></script>
+    <script src="/static/js/redeem.js"></script>
     <script>
         if (window.lucide) lucide.createIcons();
     </script>


### PR DESCRIPTION
## Summary
- switch admin static asset links to root-relative /static paths
- switch redeem page static asset links to root-relative /static paths
- avoid mixed-content failures when the app is served behind HTTPS reverse proxies

## Testing
- not run (template-only change)