### PR TITLE
fix: preserve original warranty start time

### DIFF
--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -5,7 +5,7 @@
 import logging
 import sqlite3
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,48 @@ def column_exists(cursor, table_name, column_name):
     cursor.execute(f"PRAGMA table_info({table_name})")
     columns = [row[1] for row in cursor.fetchall()]
     return column_name in columns
+
+
+def repair_warranty_timestamps(cursor) -> int:
+    """
+    用首次兑换时间回填质保起点，避免重复质保兑换重置质保期。
+    """
+    cursor.execute(
+        """
+        SELECT
+            rc.id,
+            rc.warranty_days,
+            MIN(rr.redeemed_at) AS first_redeemed_at
+        FROM redemption_codes rc
+        JOIN redemption_records rr ON rr.code = rc.code
+        WHERE rc.has_warranty = 1
+        GROUP BY rc.id, rc.warranty_days
+        """
+    )
+
+    repaired = 0
+    for code_id, warranty_days, first_redeemed_at in cursor.fetchall():
+        if not first_redeemed_at:
+            continue
+
+        first_redeemed_dt = datetime.fromisoformat(str(first_redeemed_at))
+        warranty_expires_at = first_redeemed_dt + timedelta(days=warranty_days or 30)
+
+        cursor.execute(
+            """
+            UPDATE redemption_codes
+            SET used_at = ?, warranty_expires_at = ?
+            WHERE id = ?
+            """,
+            (
+                first_redeemed_dt.isoformat(sep=" "),
+                warranty_expires_at.isoformat(sep=" "),
+                code_id,
+            ),
+        )
+        repaired += 1
+
+    return repaired
 
 
 def run_auto_migration():
@@ -106,6 +148,10 @@ def run_auto_migration():
             logger.info("添加 teams.device_code_auth_enabled 字段")
             cursor.execute("ALTER TABLE teams ADD COLUMN device_code_auth_enabled BOOLEAN DEFAULT 0")
             migrations_applied.append("teams.device_code_auth_enabled")
+
+        repaired_codes = repair_warranty_timestamps(cursor)
+        if repaired_codes:
+            migrations_applied.append(f"repair.warranty_timestamps({repaired_codes})")
         
         # 提交更改
         conn.commit()

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1295,6 +1295,8 @@ async def settings_page(
         proxy_config = await settings_service.get_proxy_config(db)
         log_level = await settings_service.get_log_level(db)
 
+        fake_success_check_enabled = await settings_service.get_setting(db, "fake_success_check_enabled", "true")
+
         return templates.TemplateResponse(
             "admin/settings/index.html",
             {
@@ -1306,7 +1308,10 @@ async def settings_page(
                 "log_level": log_level,
                 "webhook_url": await settings_service.get_setting(db, "webhook_url", ""),
                 "low_stock_threshold": await settings_service.get_setting(db, "low_stock_threshold", "10"),
-                "api_key": await settings_service.get_setting(db, "api_key", "")
+                "api_key": await settings_service.get_setting(db, "api_key", ""),
+                "fake_success_check_enabled": str(fake_success_check_enabled).lower() == "true",
+                "fake_success_check_interval": await settings_service.get_setting(db, "fake_success_check_interval", "5"),
+                "fake_success_check_count": await settings_service.get_setting(db, "fake_success_check_count", "3")
             }
         )
 
@@ -1456,6 +1461,47 @@ async def update_webhook_settings(
             "webhook_url": webhook_data.webhook_url.strip(),
             "low_stock_threshold": str(webhook_data.low_stock_threshold),
             "api_key": webhook_data.api_key.strip()
+        }
+
+        success = await settings_service.update_settings(db, settings)
+
+        if success:
+            return JSONResponse(content={"success": True, "message": "配置已保存"})
+        else:
+            return JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"success": False, "error": "保存失败"}
+            )
+
+    except Exception as e:
+        logger.error(f"更新配置失败: {e}")
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"success": False, "error": f"更新失败: {str(e)}"}
+        )
+
+class FakeSuccessSettingsRequest(BaseModel):
+    """虚假成功预警 设置请求"""
+    fake_success_check_enabled: bool = Field(True, description="是否开启虚假成功检测")
+    fake_success_check_interval: int = Field(5, description="检测间隔(秒)")
+    fake_success_check_count: int = Field(3, description="检测次数")
+
+@router.post("/settings/fake-success")
+async def update_fake_success_settings(
+    settings_data: FakeSuccessSettingsRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: dict = Depends(require_admin)
+):
+    """更新虚假成功预警配置"""
+    try:
+        from app.services.settings import settings_service
+
+        logger.info(f"管理员更新虚假成功检测配置: enabled={settings_data.fake_success_check_enabled}")
+
+        settings = {
+            "fake_success_check_enabled": str(settings_data.fake_success_check_enabled).lower(),
+            "fake_success_check_interval": str(settings_data.fake_success_check_interval),
+            "fake_success_check_count": str(settings_data.fake_success_check_count)
         }
 
         success = await settings_service.update_settings(db, settings)

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -295,20 +295,25 @@ class RedeemFlowService:
                                 raise Exception("Team账号受限: 官方拦截下发(响应空列表)，请检查账单/风控状态")
 
                             # 成功逻辑
+                            redemption_time = get_now()
+                            is_first_redemption = rc.used_at is None
+
                             rc.status = "used"
-                            rc.used_by_email = email
-                            rc.used_team_id = team_id_final
-                            rc.used_at = get_now()
-                            if rc.has_warranty:
-                                days = rc.warranty_days or 30
-                                rc.warranty_expires_at = get_now() + timedelta(days=days)
+                            if is_first_redemption:
+                                rc.used_by_email = email
+                                rc.used_team_id = team_id_final
+                                rc.used_at = redemption_time
+                                if rc.has_warranty:
+                                    days = rc.warranty_days or 30
+                                    rc.warranty_expires_at = redemption_time + timedelta(days=days)
 
                             record = RedemptionRecord(
                                 email=email,
                                 code=code,
                                 team_id=team_id_final,
                                 account_id=target_team.account_id,
-                                is_warranty_redemption=rc.has_warranty
+                                is_warranty_redemption=rc.has_warranty,
+                                redeemed_at=redemption_time
                             )
                             db_session.add(record)
                             target_team.current_members += 1

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -389,9 +389,24 @@ class RedeemFlowService:
         """
         async with AsyncSessionLocal() as db_session:
             try:
+                from app.services.settings import settings_service
+                is_enabled_str = await settings_service.get_setting(db_session, "fake_success_check_enabled", "true")
+                is_enabled = str(is_enabled_str).lower() == "true"
+                
+                if not is_enabled:
+                    logger.info(f"Team {team_id} [Background] 虚假成功检测已临时关闭，略过校验")
+                    return
+                
+                count_str = await settings_service.get_setting(db_session, "fake_success_check_count", "3")
+                interval_str = await settings_service.get_setting(db_session, "fake_success_check_interval", "5")
+                try: count = int(count_str)
+                except: count = 3
+                try: interval = int(interval_str)
+                except: interval = 5
+
                 is_verified = False
-                for i in range(3):
-                    await asyncio.sleep(5)
+                for i in range(count):
+                    await asyncio.sleep(interval)
                     # 每次同步前确保 session 是最新的
                     sync_res = await self.team_service.sync_team_info(team_id, db_session)
                     member_emails = [m.lower() for m in sync_res.get("member_emails", [])]
@@ -400,18 +415,18 @@ class RedeemFlowService:
                         logger.info(f"Team {team_id} [Background] 同步确认成功 (尝试第 {i+1} 次)")
                         break
                     
-                    if i < 2:
+                    if i < count - 1:
                         logger.warning(f"Team {team_id} [Background] 尚未见到成员 {email}，准备第 {i+2} 次重试...")
                 
                 if not is_verified:
-                    logger.error(f"检测到“虚假成功”: Team {team_id} 兑换成功但 15s 后仍查不到成员 {email}")
+                    logger.error(f"检测到“虚假成功”: Team {team_id} 兑换成功但 {count * interval}s 后仍查不到成员 {email}")
                     # 在后台标记异常
                     stmt = select(Team).where(Team.id == team_id)
                     t_res = await db_session.execute(stmt)
                     target_t = t_res.scalar_one_or_none()
                     if target_t:
                         await self.team_service._handle_api_error(
-                            {"success": False, "error": "兑换成功但 3 次同步均未见成员", "error_code": "ghost_success"},
+                            {"success": False, "error": f"兑换成功但 {count} 次同步均未见成员", "error_code": "ghost_success"},
                             target_t, db_session
                         )
             except Exception as e:

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -1476,27 +1476,42 @@ class TeamService:
                     "error": "Team账号受限: 官方拦截下发(响应空列表)，请检查账单/风控状态"
                 }
 
-            # 5. 更新成员数并二次校验邀请是否真的生效 (循环检测 3 次，防止接口返回 200 但实际延迟入库)
-            is_verified = False
-            for i in range(3):
-                await asyncio.sleep(5)
-                sync_res = await self.sync_team_info(team_id, db_session)
-                member_emails = [m.lower() for m in sync_res.get("member_emails", [])]
-                if email.lower() in member_emails:
-                    is_verified = True
-                    logger.info(f"Team {team_id} [add_member] 同步确认成功 (尝试第 {i+1} 次)")
-                    break
-                if i < 2:
-                    logger.warning(f"Team {team_id} [add_member] 尚未见到成员 {email}，准备第 {i+2} 次重试...")
+            # 5. 更新成员数并二次校验邀请是否真的生效 (防止接口返回 200 但实际延迟入库)
+            from app.services.settings import settings_service
+            is_enabled_str = await settings_service.get_setting(db_session, "fake_success_check_enabled", "true")
+            is_enabled = str(is_enabled_str).lower() == "true"
+            
+            if not is_enabled:
+                logger.info(f"Team {team_id} [add_member] 虚假成功检测已临时关闭，略过校验")
+                is_verified = True
+            else:
+                count_str = await settings_service.get_setting(db_session, "fake_success_check_count", "3")
+                interval_str = await settings_service.get_setting(db_session, "fake_success_check_interval", "5")
+                try: count = int(count_str)
+                except: count = 3
+                try: interval = int(interval_str)
+                except: interval = 5
+
+                is_verified = False
+                for i in range(count):
+                    await asyncio.sleep(interval)
+                    sync_res = await self.sync_team_info(team_id, db_session)
+                    member_emails = [m.lower() for m in sync_res.get("member_emails", [])]
+                    if email.lower() in member_emails:
+                        is_verified = True
+                        logger.info(f"Team {team_id} [add_member] 同步确认成功 (尝试第 {i+1} 次)")
+                        break
+                    if i < count - 1:
+                        logger.warning(f"Team {team_id} [add_member] 尚未见到成员 {email}，准备第 {i+2} 次重试...")
             
             if not is_verified:
-                logger.error(f"检测到“虚假成功”: Team {team_id} 发送邀请返回成功，但经过 3 次同步校验均未见该邮箱 {email}")
+                logger.error(f"检测到“虚假成功”: Team {team_id} 发送邀请返回成功，但经过 {count} 次同步校验均未见该邮箱 {email}")
                 # 标记错误
                 await self._handle_api_error({"success": False, "error": "邀请发送成功但同步列表未见成员", "error_code": "ghost_success"}, team, db_session)
                 return {
                     "success": False,
                     "message": None,
-                    "error": "邀请发送成功但 3 次同步成员列表校验均失败，该 Team 账号可能存在延迟或异常。建议稍后手动同步。"
+                    "error": f"邀请发送成功但 {count} 次同步成员列表校验均失败，该 Team 账号可能存在延迟或异常。建议稍后手动同步。"
                 }
 
             await db_session.commit()

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -6,7 +6,7 @@ import logging
 import asyncio
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
-from sqlalchemy import select, and_, or_, delete
+from sqlalchemy import select, and_, or_, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -27,6 +27,18 @@ class WarrantyService:
         """初始化质保服务"""
         from app.services.team import TeamService
         self.team_service = TeamService()
+
+    async def _get_first_redeemed_at(
+        self,
+        db_session: AsyncSession,
+        code: str
+    ) -> Optional[datetime]:
+        """获取兑换码的首次兑换时间。"""
+        stmt = select(func.min(RedemptionRecord.redeemed_at)).where(
+            RedemptionRecord.code == code
+        )
+        result = await db_session.execute(stmt)
+        return result.scalar_one_or_none()
 
     async def check_warranty_status(
         self,
@@ -193,7 +205,9 @@ class WarrantyService:
                 
                 # 如果是质保码且已使用，但到期时间为空，尝试动态计算
                 if code_obj.has_warranty and not expiry_date:
-                    start_time = code_obj.used_at or record.redeemed_at # 优先取首次使用时间
+                    start_time = await self._get_first_redeemed_at(db_session, code_obj.code)
+                    if not start_time:
+                        start_time = code_obj.used_at or record.redeemed_at
                     if start_time:
                         days = code_obj.warranty_days or 30
                         expiry_date = start_time + timedelta(days=days)

--- a/app/templates/admin/settings/index.html
+++ b/app/templates/admin/settings/index.html
@@ -87,6 +87,39 @@
     </form>
 </div>
 
+<!-- 虚假成功检测配置 -->
+<div class="content-section">
+    <div class="section-header">
+        <h3>虚假成功检测</h3>
+    </div>
+
+    <form id="fakeSuccessForm" class="settings-form">
+        <div class="form-group">
+            <label class="checkbox-label">
+                <input type="checkbox" id="fakeSuccessEnabled" name="fake_success_check_enabled" {% if fake_success_check_enabled %}checked{% endif %}>
+                <span>开启虚假成功检测</span>
+            </label>
+            <p class="form-help">启用后,拉人完成后将通过查询验证拉人是否真正成功</p>
+        </div>
+
+        <div class="form-group">
+            <label for="fakeSuccessCount">检测次数</label>
+            <input type="number" id="fakeSuccessCount" name="fake_success_check_count"
+                value="{{ fake_success_check_count or '3' }}" min="1" class="form-control">
+            <p class="form-help">同步检查的重试次数</p>
+        </div>
+
+        <div class="form-group">
+            <label for="fakeSuccessInterval">检测间隔(秒)</label>
+            <input type="number" id="fakeSuccessInterval" name="fake_success_check_interval"
+                value="{{ fake_success_check_interval or '5' }}" min="1" class="form-control">
+            <p class="form-help">每次同步检测之间等待的间隔时间</p>
+        </div>
+
+        <button type="submit" class="btn btn-primary">保存检测配置</button>
+    </form>
+</div>
+
 <!-- Webhook 配置 -->
 <div class="content-section">
     <div class="section-header">
@@ -239,6 +272,40 @@
 
             if (response.ok && data.success) {
                 showToast('日志级别已保存', 'success');
+            } else {
+                showToast(data.error || '保存失败', 'error');
+            }
+        } catch (error) {
+            showToast('网络错误', 'error');
+        }
+    });
+
+    // 虚假成功检测配置表单
+    document.getElementById('fakeSuccessForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const fake_success_check_enabled = document.getElementById('fakeSuccessEnabled').checked;
+        const fake_success_check_count = parseInt(document.getElementById('fakeSuccessCount').value);
+        const fake_success_check_interval = parseInt(document.getElementById('fakeSuccessInterval').value);
+
+        if (isNaN(fake_success_check_count) || fake_success_check_count < 1 || isNaN(fake_success_check_interval) || fake_success_check_interval < 1) {
+            showToast('请输入有效的检测次数和间隔', 'error');
+            return;
+        }
+
+        try {
+            const response = await fetch('/admin/settings/fake-success', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ fake_success_check_enabled, fake_success_check_count, fake_success_check_interval })
+            });
+
+            const data = await response.json();
+
+            if (response.ok && data.success) {
+                showToast('虚假成功检测配置已保存', 'success');
             } else {
                 showToast(data.error || '保存失败', 'error');
             }

--- a/tests/test_warranty_issue20.py
+++ b/tests/test_warranty_issue20.py
@@ -1,0 +1,236 @@
+import sqlite3
+import unittest
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine as real_create_async_engine
+import sqlalchemy.ext.asyncio as sqlalchemy_asyncio
+
+_original_create_async_engine = sqlalchemy_asyncio.create_async_engine
+sqlalchemy_asyncio.create_async_engine = lambda *args, **kwargs: None
+
+from app.database import Base
+from app.db_migrations import repair_warranty_timestamps
+from app.models import RedemptionCode, Team
+from app.services.redeem_flow import RedeemFlowService
+from app.services.warranty import WarrantyService
+from app.utils.time_utils import get_now
+
+sqlalchemy_asyncio.create_async_engine = _original_create_async_engine
+
+
+def _discard_task(coro):
+    coro.close()
+    return None
+
+
+class WarrantyIssue20Tests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = real_create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def test_repeated_warranty_redemption_preserves_original_timestamps(self):
+        async with self.session_factory() as session:
+            first_team = Team(
+                email="owner1@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-1",
+                team_name="Team One",
+                current_members=0,
+                max_members=6,
+                status="active",
+            )
+            second_team = Team(
+                email="owner2@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-2",
+                team_name="Team Two",
+                current_members=0,
+                max_members=6,
+                status="active",
+            )
+            code = RedemptionCode(
+                code="WARRANTY20",
+                status="unused",
+                has_warranty=True,
+                warranty_days=30,
+            )
+            session.add_all([first_team, second_team, code])
+            await session.commit()
+
+            service = RedeemFlowService()
+            service.select_team_auto = AsyncMock(return_value={"success": True, "team_id": first_team.id, "error": None})
+            service.team_service.sync_team_info = AsyncMock(return_value={"success": True, "member_emails": []})
+            service.team_service.ensure_access_token = AsyncMock(return_value="token")
+            service.chatgpt_service.send_invite = AsyncMock(
+                return_value={"success": True, "data": {"account_invites": [{"email": "user@example.com"}]}}
+            )
+
+            with patch("app.services.redeem_flow.asyncio.create_task", new=_discard_task):
+                first_result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="WARRANTY20",
+                    team_id=first_team.id,
+                    db_session=session,
+                )
+
+            self.assertTrue(first_result["success"])
+
+            first_code = await session.scalar(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY20")
+            )
+            original_used_at = first_code.used_at
+            original_expiry = first_code.warranty_expires_at
+
+            self.assertIsNotNone(original_used_at)
+            self.assertEqual(original_expiry, original_used_at + timedelta(days=30))
+
+            first_team.status = "banned"
+            second_team.status = "active"
+            await session.commit()
+
+            with patch("app.services.redeem_flow.asyncio.create_task", new=_discard_task):
+                second_result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="WARRANTY20",
+                    team_id=second_team.id,
+                    db_session=session,
+                )
+
+            self.assertTrue(second_result["success"])
+
+            updated_code = await session.scalar(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY20")
+            )
+            self.assertEqual(updated_code.used_at, original_used_at)
+            self.assertEqual(updated_code.warranty_expires_at, original_expiry)
+
+    async def test_warranty_status_falls_back_to_first_redemption_record(self):
+        async with self.session_factory() as session:
+            team = Team(
+                email="owner@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-main",
+                team_name="Main Team",
+                current_members=0,
+                max_members=6,
+                status="banned",
+            )
+            code = RedemptionCode(
+                code="WARRANTY-CHECK",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_at=None,
+                warranty_expires_at=None,
+            )
+            session.add_all([team, code])
+            await session.flush()
+
+            first_redeem_at = get_now() - timedelta(days=12)
+            second_redeem_at = get_now() - timedelta(days=2)
+            from app.models import RedemptionRecord
+
+            session.add_all(
+                [
+                    RedemptionRecord(
+                        email="user@example.com",
+                        code="WARRANTY-CHECK",
+                        team_id=team.id,
+                        account_id=team.account_id,
+                        redeemed_at=first_redeem_at,
+                        is_warranty_redemption=True,
+                    ),
+                    RedemptionRecord(
+                        email="user@example.com",
+                        code="WARRANTY-CHECK",
+                        team_id=team.id,
+                        account_id=team.account_id,
+                        redeemed_at=second_redeem_at,
+                        is_warranty_redemption=True,
+                    ),
+                ]
+            )
+            await session.commit()
+
+            service = WarrantyService()
+            result = await service.check_warranty_status(session, code="WARRANTY-CHECK")
+
+            self.assertTrue(result["success"])
+            self.assertEqual(
+                result["warranty_expires_at"],
+                (first_redeem_at + timedelta(days=30)).isoformat(),
+            )
+
+    def test_repair_warranty_timestamps_uses_first_redemption_record(self):
+        conn = sqlite3.connect(":memory:")
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE redemption_codes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT UNIQUE NOT NULL,
+                has_warranty BOOLEAN DEFAULT 0,
+                warranty_days INTEGER DEFAULT 30,
+                used_at DATETIME,
+                warranty_expires_at DATETIME
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE redemption_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT NOT NULL,
+                redeemed_at DATETIME
+            )
+            """
+        )
+
+        cursor.execute(
+            """
+            INSERT INTO redemption_codes (code, has_warranty, warranty_days, used_at, warranty_expires_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("FIXME20", 1, 30, "2026-03-10 10:00:00", "2026-04-09 10:00:00"),
+        )
+        cursor.executemany(
+            """
+            INSERT INTO redemption_records (code, redeemed_at)
+            VALUES (?, ?)
+            """,
+            [
+                ("FIXME20", "2026-03-01 08:00:00"),
+                ("FIXME20", "2026-03-10 10:00:00"),
+            ],
+        )
+
+        repaired = repair_warranty_timestamps(cursor)
+        conn.commit()
+
+        self.assertEqual(repaired, 1)
+
+        cursor.execute(
+            "SELECT used_at, warranty_expires_at FROM redemption_codes WHERE code = ?",
+            ("FIXME20",),
+        )
+        used_at, warranty_expires_at = cursor.fetchone()
+        self.assertEqual(used_at, "2026-03-01 08:00:00")
+        self.assertEqual(warranty_expires_at, "2026-03-31 08:00:00")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve used_at and warranty_expires_at from the first successful warranty redemption
- stop resetting the warranty window on later warranty reuses
- repair existing warranty codes during auto-migration using the earliest redemption record
- add regression tests for repeated warranty redemptions and migration repair

## Testing
- python -m unittest discover -s tests -p test_warranty_issue20.py

Closes #20
