### PR TITLE
fix: preserve original warranty start time

### DIFF
--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -5,7 +5,7 @@
 import logging
 import sqlite3
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,48 @@ def column_exists(cursor, table_name, column_name):
     cursor.execute(f"PRAGMA table_info({table_name})")
     columns = [row[1] for row in cursor.fetchall()]
     return column_name in columns
+
+
+def repair_warranty_timestamps(cursor) -> int:
+    """
+    用首次兑换时间回填质保起点，避免重复质保兑换重置质保期。
+    """
+    cursor.execute(
+        """
+        SELECT
+            rc.id,
+            rc.warranty_days,
+            MIN(rr.redeemed_at) AS first_redeemed_at
+        FROM redemption_codes rc
+        JOIN redemption_records rr ON rr.code = rc.code
+        WHERE rc.has_warranty = 1
+        GROUP BY rc.id, rc.warranty_days
+        """
+    )
+
+    repaired = 0
+    for code_id, warranty_days, first_redeemed_at in cursor.fetchall():
+        if not first_redeemed_at:
+            continue
+
+        first_redeemed_dt = datetime.fromisoformat(str(first_redeemed_at))
+        warranty_expires_at = first_redeemed_dt + timedelta(days=warranty_days or 30)
+
+        cursor.execute(
+            """
+            UPDATE redemption_codes
+            SET used_at = ?, warranty_expires_at = ?
+            WHERE id = ?
+            """,
+            (
+                first_redeemed_dt.isoformat(sep=" "),
+                warranty_expires_at.isoformat(sep=" "),
+                code_id,
+            ),
+        )
+        repaired += 1
+
+    return repaired
 
 
 def run_auto_migration():
@@ -106,6 +148,10 @@ def run_auto_migration():
             logger.info("添加 teams.device_code_auth_enabled 字段")
             cursor.execute("ALTER TABLE teams ADD COLUMN device_code_auth_enabled BOOLEAN DEFAULT 0")
             migrations_applied.append("teams.device_code_auth_enabled")
+
+        repaired_codes = repair_warranty_timestamps(cursor)
+        if repaired_codes:
+            migrations_applied.append(f"repair.warranty_timestamps({repaired_codes})")
         
         # 提交更改
         conn.commit()

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -295,20 +295,25 @@ class RedeemFlowService:
                                 raise Exception("Team账号受限: 官方拦截下发(响应空列表)，请检查账单/风控状态")
 
                             # 成功逻辑
+                            redemption_time = get_now()
+                            is_first_redemption = rc.used_at is None
+
                             rc.status = "used"
-                            rc.used_by_email = email
-                            rc.used_team_id = team_id_final
-                            rc.used_at = get_now()
-                            if rc.has_warranty:
-                                days = rc.warranty_days or 30
-                                rc.warranty_expires_at = get_now() + timedelta(days=days)
+                            if is_first_redemption:
+                                rc.used_by_email = email
+                                rc.used_team_id = team_id_final
+                                rc.used_at = redemption_time
+                                if rc.has_warranty:
+                                    days = rc.warranty_days or 30
+                                    rc.warranty_expires_at = redemption_time + timedelta(days=days)
 
                             record = RedemptionRecord(
                                 email=email,
                                 code=code,
                                 team_id=team_id_final,
                                 account_id=target_team.account_id,
-                                is_warranty_redemption=rc.has_warranty
+                                is_warranty_redemption=rc.has_warranty,
+                                redeemed_at=redemption_time
                             )
                             db_session.add(record)
                             target_team.current_members += 1

--- a/app/services/warranty.py
+++ b/app/services/warranty.py
@@ -6,7 +6,7 @@ import logging
 import asyncio
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timedelta
-from sqlalchemy import select, and_, or_, delete
+from sqlalchemy import select, and_, or_, delete, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -27,6 +27,18 @@ class WarrantyService:
         """初始化质保服务"""
         from app.services.team import TeamService
         self.team_service = TeamService()
+
+    async def _get_first_redeemed_at(
+        self,
+        db_session: AsyncSession,
+        code: str
+    ) -> Optional[datetime]:
+        """获取兑换码的首次兑换时间。"""
+        stmt = select(func.min(RedemptionRecord.redeemed_at)).where(
+            RedemptionRecord.code == code
+        )
+        result = await db_session.execute(stmt)
+        return result.scalar_one_or_none()
 
     async def check_warranty_status(
         self,
@@ -193,7 +205,9 @@ class WarrantyService:
                 
                 # 如果是质保码且已使用，但到期时间为空，尝试动态计算
                 if code_obj.has_warranty and not expiry_date:
-                    start_time = code_obj.used_at or record.redeemed_at # 优先取首次使用时间
+                    start_time = await self._get_first_redeemed_at(db_session, code_obj.code)
+                    if not start_time:
+                        start_time = code_obj.used_at or record.redeemed_at
                     if start_time:
                         days = code_obj.warranty_days or 30
                         expiry_date = start_time + timedelta(days=days)

--- a/tests/test_warranty_issue20.py
+++ b/tests/test_warranty_issue20.py
@@ -1,0 +1,236 @@
+import sqlite3
+import unittest
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine as real_create_async_engine
+import sqlalchemy.ext.asyncio as sqlalchemy_asyncio
+
+_original_create_async_engine = sqlalchemy_asyncio.create_async_engine
+sqlalchemy_asyncio.create_async_engine = lambda *args, **kwargs: None
+
+from app.database import Base
+from app.db_migrations import repair_warranty_timestamps
+from app.models import RedemptionCode, Team
+from app.services.redeem_flow import RedeemFlowService
+from app.services.warranty import WarrantyService
+from app.utils.time_utils import get_now
+
+sqlalchemy_asyncio.create_async_engine = _original_create_async_engine
+
+
+def _discard_task(coro):
+    coro.close()
+    return None
+
+
+class WarrantyIssue20Tests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = real_create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def test_repeated_warranty_redemption_preserves_original_timestamps(self):
+        async with self.session_factory() as session:
+            first_team = Team(
+                email="owner1@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-1",
+                team_name="Team One",
+                current_members=0,
+                max_members=6,
+                status="active",
+            )
+            second_team = Team(
+                email="owner2@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-2",
+                team_name="Team Two",
+                current_members=0,
+                max_members=6,
+                status="active",
+            )
+            code = RedemptionCode(
+                code="WARRANTY20",
+                status="unused",
+                has_warranty=True,
+                warranty_days=30,
+            )
+            session.add_all([first_team, second_team, code])
+            await session.commit()
+
+            service = RedeemFlowService()
+            service.select_team_auto = AsyncMock(return_value={"success": True, "team_id": first_team.id, "error": None})
+            service.team_service.sync_team_info = AsyncMock(return_value={"success": True, "member_emails": []})
+            service.team_service.ensure_access_token = AsyncMock(return_value="token")
+            service.chatgpt_service.send_invite = AsyncMock(
+                return_value={"success": True, "data": {"account_invites": [{"email": "user@example.com"}]}}
+            )
+
+            with patch("app.services.redeem_flow.asyncio.create_task", new=_discard_task):
+                first_result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="WARRANTY20",
+                    team_id=first_team.id,
+                    db_session=session,
+                )
+
+            self.assertTrue(first_result["success"])
+
+            first_code = await session.scalar(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY20")
+            )
+            original_used_at = first_code.used_at
+            original_expiry = first_code.warranty_expires_at
+
+            self.assertIsNotNone(original_used_at)
+            self.assertEqual(original_expiry, original_used_at + timedelta(days=30))
+
+            first_team.status = "banned"
+            second_team.status = "active"
+            await session.commit()
+
+            with patch("app.services.redeem_flow.asyncio.create_task", new=_discard_task):
+                second_result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="WARRANTY20",
+                    team_id=second_team.id,
+                    db_session=session,
+                )
+
+            self.assertTrue(second_result["success"])
+
+            updated_code = await session.scalar(
+                select(RedemptionCode).where(RedemptionCode.code == "WARRANTY20")
+            )
+            self.assertEqual(updated_code.used_at, original_used_at)
+            self.assertEqual(updated_code.warranty_expires_at, original_expiry)
+
+    async def test_warranty_status_falls_back_to_first_redemption_record(self):
+        async with self.session_factory() as session:
+            team = Team(
+                email="owner@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-main",
+                team_name="Main Team",
+                current_members=0,
+                max_members=6,
+                status="banned",
+            )
+            code = RedemptionCode(
+                code="WARRANTY-CHECK",
+                status="used",
+                has_warranty=True,
+                warranty_days=30,
+                used_at=None,
+                warranty_expires_at=None,
+            )
+            session.add_all([team, code])
+            await session.flush()
+
+            first_redeem_at = get_now() - timedelta(days=12)
+            second_redeem_at = get_now() - timedelta(days=2)
+            from app.models import RedemptionRecord
+
+            session.add_all(
+                [
+                    RedemptionRecord(
+                        email="user@example.com",
+                        code="WARRANTY-CHECK",
+                        team_id=team.id,
+                        account_id=team.account_id,
+                        redeemed_at=first_redeem_at,
+                        is_warranty_redemption=True,
+                    ),
+                    RedemptionRecord(
+                        email="user@example.com",
+                        code="WARRANTY-CHECK",
+                        team_id=team.id,
+                        account_id=team.account_id,
+                        redeemed_at=second_redeem_at,
+                        is_warranty_redemption=True,
+                    ),
+                ]
+            )
+            await session.commit()
+
+            service = WarrantyService()
+            result = await service.check_warranty_status(session, code="WARRANTY-CHECK")
+
+            self.assertTrue(result["success"])
+            self.assertEqual(
+                result["warranty_expires_at"],
+                (first_redeem_at + timedelta(days=30)).isoformat(),
+            )
+
+    def test_repair_warranty_timestamps_uses_first_redemption_record(self):
+        conn = sqlite3.connect(":memory:")
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE redemption_codes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT UNIQUE NOT NULL,
+                has_warranty BOOLEAN DEFAULT 0,
+                warranty_days INTEGER DEFAULT 30,
+                used_at DATETIME,
+                warranty_expires_at DATETIME
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE redemption_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT NOT NULL,
+                redeemed_at DATETIME
+            )
+            """
+        )
+
+        cursor.execute(
+            """
+            INSERT INTO redemption_codes (code, has_warranty, warranty_days, used_at, warranty_expires_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("FIXME20", 1, 30, "2026-03-10 10:00:00", "2026-04-09 10:00:00"),
+        )
+        cursor.executemany(
+            """
+            INSERT INTO redemption_records (code, redeemed_at)
+            VALUES (?, ?)
+            """,
+            [
+                ("FIXME20", "2026-03-01 08:00:00"),
+                ("FIXME20", "2026-03-10 10:00:00"),
+            ],
+        )
+
+        repaired = repair_warranty_timestamps(cursor)
+        conn.commit()
+
+        self.assertEqual(repaired, 1)
+
+        cursor.execute(
+            "SELECT used_at, warranty_expires_at FROM redemption_codes WHERE code = ?",
+            ("FIXME20",),
+        )
+        used_at, warranty_expires_at = cursor.fetchone()
+        self.assertEqual(used_at, "2026-03-01 08:00:00")
+        self.assertEqual(warranty_expires_at, "2026-03-31 08:00:00")
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve used_at and warranty_expires_at from the first successful warranty redemption
- stop resetting the warranty window on later warranty reuses
- repair existing warranty codes during auto-migration using the earliest redemption record
- add regression tests for repeated warranty redemptions and migration repair

## Testing
- python -m unittest discover -s tests -p test_warranty_issue20.py

Closes #20
