### PR TITLE
Fix team capacity accounting for pending invites

### DIFF
--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -149,6 +149,11 @@ def run_auto_migration():
             cursor.execute("ALTER TABLE teams ADD COLUMN device_code_auth_enabled BOOLEAN DEFAULT 0")
             migrations_applied.append("teams.device_code_auth_enabled")
 
+        if not column_exists(cursor, "teams", "pending_invites"):
+            logger.info("添加 teams.pending_invites 字段")
+            cursor.execute("ALTER TABLE teams ADD COLUMN pending_invites INTEGER DEFAULT 0")
+            migrations_applied.append("teams.pending_invites")
+
         repaired_codes = repair_warranty_timestamps(cursor)
         if repaired_codes:
             migrations_applied.append(f"repair.warranty_timestamps({repaired_codes})")

--- a/app/models.py
+++ b/app/models.py
@@ -26,6 +26,7 @@ class Team(Base):
     subscription_plan = Column(String(100), comment="订阅计划")
     expires_at = Column(DateTime, comment="订阅到期时间")
     current_members = Column(Integer, default=0, comment="当前成员数")
+    pending_invites = Column(Integer, default=0, comment="待接受邀请数")
     max_members = Column(Integer, default=6, comment="最大成员数")
     status = Column(String(20), default="active", comment="状态: active/full/expired/error/banned")
     account_role = Column(String(50), comment="账号角色: account-owner/standard-user 等")

--- a/app/services/redeem_flow.py
+++ b/app/services/redeem_flow.py
@@ -119,19 +119,22 @@ class RedeemFlowService:
         """
         try:
             # 查找所有 active 且未满的 Team
-            stmt = select(Team).where(
-                Team.status == "active",
-                Team.current_members < Team.max_members
-            )
+            stmt = select(Team).where(Team.status == "active")
             
             if exclude_team_ids:
                 stmt = stmt.where(Team.id.not_in(exclude_team_ids))
-            
-            # 优先选择人数最少的 Team (负载均衡)
-            stmt = stmt.order_by(Team.current_members.asc(), Team.created_at.desc())
-            
+
             result = await db_session.execute(stmt)
-            team = result.scalars().first()
+            teams = [team for team in result.scalars().all() if self.team_service._remaining_slots(team) > 0]
+
+            # 优先选择已占用席位最少的 Team (负载均衡)，同占用量时优先较新的 Team
+            teams.sort(
+                key=lambda team: (
+                    self.team_service._occupied_slots(team),
+                    -(team.created_at.timestamp() if team.created_at else 0),
+                )
+            )
+            team = teams[0] if teams else None
 
             if not team:
                 reason = "没有可用的 Team"
@@ -238,7 +241,7 @@ class RedeemFlowService:
                             if not target_team or target_team.status != "active":
                                 raise Exception(f"目标 Team {team_id_final} 不可用 ({target_team.status if target_team else 'None'})")
                             
-                            if target_team.current_members >= target_team.max_members:
+                            if self.team_service._occupied_slots(target_team) >= target_team.max_members:
                                 target_team.status = "full"
                                 raise Exception("该 Team 已满, 请选择其他 Team 尝试")
 
@@ -316,8 +319,8 @@ class RedeemFlowService:
                                 redeemed_at=redemption_time
                             )
                             db_session.add(record)
-                            target_team.current_members += 1
-                            if target_team.current_members >= target_team.max_members:
+                            target_team.pending_invites = (target_team.pending_invites or 0) + 1
+                            if self.team_service._occupied_slots(target_team) >= target_team.max_members:
                                 target_team.status = "full"
                             
                             await db_session.commit()

--- a/app/services/team.py
+++ b/app/services/team.py
@@ -30,6 +30,18 @@ class TeamService:
         self.token_parser = TokenParser()
         self.jwt_parser = JWTParser()
 
+    @staticmethod
+    def _pending_invites(team: Team) -> int:
+        return team.pending_invites or 0
+
+    @classmethod
+    def _occupied_slots(cls, team: Team) -> int:
+        return (team.current_members or 0) + cls._pending_invites(team)
+
+    @classmethod
+    def _remaining_slots(cls, team: Team) -> int:
+        return max((team.max_members or 0) - cls._occupied_slots(team), 0)
+
     async def _handle_api_error(self, result: Dict[str, Any], team: Team, db_session: AsyncSession) -> bool:
         """
         检查结果是否表示账号被封禁、Token 失效或 Team 已满,如果是则更新状态
@@ -98,13 +110,11 @@ class TeamService:
         if any(kw in error_msg for kw in full_keywords):
             logger.warning(f"检测到 Team 席位已满 (msg={error_msg}), 更新 Team {team.id} ({team.email}) 状态为 full")
             team.status = "full"
+            occupied_slots = self._occupied_slots(team)
             # 学习真实的席位上限: 如果当前探测到的成员数小于预设的最大值，说明该团队实际容量较小
-            if team.current_members > 0 and team.current_members < team.max_members:
-                logger.info(f"修正 Team {team.id} 的最大成员数: {team.max_members} -> {team.current_members}")
-                team.max_members = team.current_members
-            elif team.current_members >= team.max_members:
-                # 进位修正，确保逻辑闭环
-                team.current_members = team.max_members
+            if occupied_slots > 0 and occupied_slots < team.max_members:
+                logger.info(f"修正 Team {team.id} 的最大成员数: {team.max_members} -> {occupied_slots}")
+                team.max_members = occupied_slots
 
             if not db_session.in_transaction():
                 await db_session.commit()
@@ -151,7 +161,7 @@ class TeamService:
         team.error_count = 0
         if team.status == "error":
             # 恢复时也要校验是否满员或到期
-            if team.current_members >= team.max_members:
+            if self._occupied_slots(team) >= team.max_members:
                 logger.info(f"Team {team.id} ({team.email}) 请求成功, 将状态从 error 恢复为 full")
                 team.status = "full"
             elif team.expires_at and team.expires_at < datetime.now():
@@ -434,10 +444,12 @@ class TeamService:
                 )
 
                 current_members = 0
+                pending_invites = 0
                 if members_result["success"]:
-                    current_members += members_result["total"]
+                    current_members = members_result["total"]
                 if invites_result["success"]:
-                    current_members += invites_result["total"]
+                    pending_invites = invites_result["total"]
+                occupied_slots = current_members + pending_invites
 
                 # 解析过期时间
                 expires_at = None
@@ -465,7 +477,7 @@ class TeamService:
                 # 确定状态和最大成员数 (默认 6)
                 max_members = 6
                 status = "active"
-                if current_members >= max_members:
+                if occupied_slots >= max_members:
                     status = "full"
                 elif expires_at and expires_at < datetime.now():
                     status = "expired"
@@ -489,6 +501,7 @@ class TeamService:
                     subscription_plan=selected_account["subscription_plan"],
                     expires_at=expires_at,
                     current_members=current_members,
+                    pending_invites=pending_invites,
                     max_members=max_members,
                     status=status,
                     account_role=selected_account.get("account_user_role"),
@@ -638,7 +651,7 @@ class TeamService:
             
             # 自动维护 active/full/expired 状态 (仅当当前处于这三者之一或刚更新了 max_members/status)
             if team.status in ["active", "full", "expired"]:
-                if team.current_members >= team.max_members:
+                if self._occupied_slots(team) >= team.max_members:
                     team.status = "full"
                 elif team.expires_at and team.expires_at < datetime.now():
                     team.status = "expired"
@@ -974,14 +987,15 @@ class TeamService:
 
             all_member_emails = set()
             current_members = 0
+            pending_invites = 0
             if members_result["success"]:
-                current_members += members_result["total"]
+                current_members = members_result["total"]
                 for m in members_result.get("members", []):
                     if m.get("email"):
                         all_member_emails.add(m["email"].lower())
             
             if invites_result["success"]:
-                current_members += invites_result["total"]
+                pending_invites = invites_result["total"]
                 for inv in invites_result.get("items", []):
                     if inv.get("email_address"):
                         all_member_emails.add(inv["email_address"].lower())
@@ -1036,7 +1050,8 @@ class TeamService:
 
             # 7. 确定状态
             status = "active"
-            if current_members >= team.max_members:
+            occupied_slots = current_members + pending_invites
+            if occupied_slots >= team.max_members:
                 status = "full"
             elif expires_at and expires_at < datetime.now():
                 status = "expired"
@@ -1049,6 +1064,7 @@ class TeamService:
             team.account_role = current_account.get("account_user_role")
             team.expires_at = expires_at
             team.current_members = current_members
+            team.pending_invites = pending_invites
             team.status = status
             team.device_code_auth_enabled = device_code_auth_enabled
             team.error_count = 0  # 同步成功，重置错误次数
@@ -1059,11 +1075,13 @@ class TeamService:
             else:
                 await db_session.flush()
 
-            logger.info(f"Team 同步成功: ID {team_id}, 成员数 {current_members}")
+            logger.info(
+                f"Team 同步成功: ID {team_id}, 已加入成员 {current_members}, 待接受邀请 {pending_invites}"
+            )
 
             return {
                 "success": True,
-                "message": f"同步成功,当前成员数: {current_members}",
+                "message": f"同步成功,已加入成员: {current_members}, 待接受邀请: {pending_invites}",
                 "member_emails": list(all_member_emails),
                 "error": None
             }
@@ -1427,6 +1445,15 @@ class TeamService:
                     "error": "Team 已过期,无法添加成员"
                 }
 
+            if self._occupied_slots(team) >= team.max_members:
+                team.status = "full"
+                await db_session.commit()
+                return {
+                    "success": False,
+                    "message": None,
+                    "error": "Team 已满,无法添加成员"
+                }
+
             # 3. 确保 AT Token 有效
             access_token = await self.ensure_access_token(team, db_session)
             if not access_token:
@@ -1475,6 +1502,11 @@ class TeamService:
                     "message": None,
                     "error": "Team账号受限: 官方拦截下发(响应空列表)，请检查账单/风控状态"
                 }
+
+            team.pending_invites = (team.pending_invites or 0) + 1
+            if self._occupied_slots(team) >= team.max_members:
+                team.status = "full"
+            await db_session.commit()
 
             # 5. 更新成员数并二次校验邀请是否真的生效 (循环检测 3 次，防止接口返回 200 但实际延迟入库)
             is_verified = False
@@ -1675,21 +1707,22 @@ class TeamService:
             结果字典,包含 success, teams, error
         """
         try:
-            # 查询 status='active' 且 current_members < max_members 的 Team
-            stmt = select(Team).where(
-                Team.status == "active",
-                Team.current_members < Team.max_members
-            )
+            # 查询所有活跃 Team，再基于已加入成员和待接受邀请做容量过滤
+            stmt = select(Team).where(Team.status == "active")
             result = await db_session.execute(stmt)
             teams = result.scalars().all()
 
             # 构建返回数据 (不包含敏感信息)
             team_list = []
             for team in teams:
+                if self._remaining_slots(team) <= 0:
+                    continue
                 team_list.append({
                     "id": team.id,
                     "team_name": team.team_name,
                     "current_members": team.current_members,
+                    "pending_invites": self._pending_invites(team),
+                    "occupied_slots": self._occupied_slots(team),
                     "max_members": team.max_members,
                     "expires_at": team.expires_at.isoformat() if team.expires_at else None,
                     "subscription_plan": team.subscription_plan
@@ -1773,6 +1806,8 @@ class TeamService:
                 "subscription_plan": team.subscription_plan,
                 "expires_at": team.expires_at.isoformat() if team.expires_at else None,
                 "current_members": team.current_members,
+                "pending_invites": self._pending_invites(team),
+                "occupied_slots": self._occupied_slots(team),
                 "max_members": team.max_members,
                 "status": team.status,
                 "device_code_auth_enabled": team.device_code_auth_enabled,
@@ -1881,6 +1916,8 @@ class TeamService:
                     "subscription_plan": team.subscription_plan,
                     "expires_at": team.expires_at.isoformat() if team.expires_at else None,
                     "current_members": team.current_members,
+                    "pending_invites": self._pending_invites(team),
+                    "occupied_slots": self._occupied_slots(team),
                     "max_members": team.max_members,
                     "status": team.status,
                     "device_code_auth_enabled": getattr(team, 'device_code_auth_enabled', False),
@@ -2014,12 +2051,10 @@ class TeamService:
         """
         try:
             # 统计所有状态为 active 的 Team 的剩余位置
-            stmt = select(func.sum(Team.max_members - Team.current_members)).where(
-                Team.status == "active",
-                Team.current_members < Team.max_members
-            )
+            stmt = select(Team).where(Team.status == "active")
             result = await db_session.execute(stmt)
-            return result.scalar() or 0
+            teams = result.scalars().all()
+            return sum(self._remaining_slots(team) for team in teams)
         except Exception as e:
             logger.error(f"获取总可用车位数失败: {e}")
             return 0
@@ -2036,12 +2071,10 @@ class TeamService:
             total = total_result.scalar() or 0
             
             # 可用 Team 数 (状态为 active 且未满)
-            available_stmt = select(func.count(Team.id)).where(
-                Team.status == "active",
-                Team.current_members < Team.max_members
-            )
+            available_stmt = select(Team).where(Team.status == "active")
             available_result = await db_session.execute(available_stmt)
-            available = available_result.scalar() or 0
+            available_teams = available_result.scalars().all()
+            available = sum(1 for team in available_teams if self._remaining_slots(team) > 0)
             
             return {
                 "total": total,

--- a/tests/test_issue10_pending_invites.py
+++ b/tests/test_issue10_pending_invites.py
@@ -1,0 +1,182 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine as real_create_async_engine
+import sqlalchemy.ext.asyncio as sqlalchemy_asyncio
+
+_original_create_async_engine = sqlalchemy_asyncio.create_async_engine
+sqlalchemy_asyncio.create_async_engine = lambda *args, **kwargs: None
+
+from app.database import Base
+from app.models import RedemptionCode, Team
+from app.services.redeem_flow import RedeemFlowService
+from app.services.team import TeamService
+
+sqlalchemy_asyncio.create_async_engine = _original_create_async_engine
+
+
+def _discard_task(coro):
+    coro.close()
+    return None
+
+
+class PendingInviteCapacityTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.engine = real_create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        self.session_factory = async_sessionmaker(
+            self.engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+            autoflush=False,
+        )
+
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    async def asyncTearDown(self):
+        await self.engine.dispose()
+
+    async def test_total_available_seats_subtracts_pending_invites(self):
+        async with self.session_factory() as session:
+            session.add_all(
+                [
+                    Team(
+                        email="full@example.com",
+                        access_token_encrypted="enc",
+                        account_id="acct-full",
+                        team_name="Full By Invite",
+                        current_members=4,
+                        pending_invites=1,
+                        max_members=5,
+                        status="active",
+                    ),
+                    Team(
+                        email="available@example.com",
+                        access_token_encrypted="enc",
+                        account_id="acct-available",
+                        team_name="Still Available",
+                        current_members=2,
+                        pending_invites=1,
+                        max_members=5,
+                        status="active",
+                    ),
+                    Team(
+                        email="expired@example.com",
+                        access_token_encrypted="enc",
+                        account_id="acct-expired",
+                        team_name="Expired Team",
+                        current_members=0,
+                        pending_invites=0,
+                        max_members=5,
+                        status="expired",
+                    ),
+                ]
+            )
+            await session.commit()
+
+            seats = await TeamService().get_total_available_seats(session)
+
+            self.assertEqual(seats, 2)
+
+    async def test_select_team_auto_skips_team_filled_by_pending_invites(self):
+        async with self.session_factory() as session:
+            blocked_team = Team(
+                email="blocked@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-blocked",
+                team_name="Blocked Team",
+                current_members=4,
+                pending_invites=1,
+                max_members=5,
+                status="active",
+            )
+            available_team = Team(
+                email="available@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-available",
+                team_name="Available Team",
+                current_members=3,
+                pending_invites=0,
+                max_members=5,
+                status="active",
+            )
+            session.add_all([blocked_team, available_team])
+            await session.commit()
+
+            result = await RedeemFlowService().select_team_auto(session)
+
+            self.assertTrue(result["success"])
+            self.assertEqual(result["team_id"], available_team.id)
+
+    async def test_add_team_member_rejects_full_team_when_pending_invites_fill_capacity(self):
+        async with self.session_factory() as session:
+            team = Team(
+                email="owner@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-owner",
+                team_name="Pending Full Team",
+                current_members=4,
+                pending_invites=1,
+                max_members=5,
+                status="active",
+            )
+            session.add(team)
+            await session.commit()
+
+            service = TeamService()
+            service.ensure_access_token = AsyncMock(return_value="token")
+            service.chatgpt_service.send_invite = AsyncMock(
+                return_value={"success": True, "data": {"account_invites": [{"email": "new@example.com"}]}}
+            )
+
+            result = await service.add_team_member(team.id, "new@example.com", session)
+
+            self.assertFalse(result["success"])
+            self.assertIn("已满", result["error"])
+            service.chatgpt_service.send_invite.assert_not_called()
+
+            refreshed_team = await session.scalar(select(Team).where(Team.id == team.id))
+            self.assertEqual(refreshed_team.status, "full")
+
+    async def test_redeem_flow_reserves_pending_invite_slot_after_success(self):
+        async with self.session_factory() as session:
+            team = Team(
+                email="owner@example.com",
+                access_token_encrypted="enc",
+                account_id="acct-main",
+                team_name="Main Team",
+                current_members=3,
+                pending_invites=1,
+                max_members=5,
+                status="active",
+            )
+            code = RedemptionCode(code="ISSUE10", status="unused")
+            session.add_all([team, code])
+            await session.commit()
+
+            service = RedeemFlowService()
+            service.team_service.sync_team_info = AsyncMock(return_value={"success": True, "member_emails": []})
+            service.team_service.ensure_access_token = AsyncMock(return_value="token")
+            service.chatgpt_service.send_invite = AsyncMock(
+                return_value={"success": True, "data": {"account_invites": [{"email": "user@example.com"}]}}
+            )
+
+            with patch("app.services.redeem_flow.asyncio.create_task", new=_discard_task):
+                result = await service.redeem_and_join_team(
+                    email="user@example.com",
+                    code="ISSUE10",
+                    team_id=team.id,
+                    db_session=session,
+                )
+
+            self.assertTrue(result["success"])
+
+            refreshed_team = await session.scalar(select(Team).where(Team.id == team.id))
+            self.assertEqual(refreshed_team.current_members, 3)
+            self.assertEqual(refreshed_team.pending_invites, 2)
+            self.assertEqual(refreshed_team.status, "full")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `pending_invites` to `Team` and migrate existing databases automatically
- count `current_members + pending_invites` for availability, full-state transitions, and redeem auto-selection
- reserve pending invite slots immediately after a successful invite and add regression tests for issue #10

## Testing
- `python -m unittest discover -s tests`

Closes #10